### PR TITLE
stop requiring the CSS file from JavaScript.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All the changes made to toastify-js library.
 
+## [1.4] - 2019-05-12
+
+* **Breaking Change**: Manually import CSS while using as module in your modern JavaScript applications.
+* Ability to pause the toast dismiss timer on hover (Using `stopOnFocus` property)
+
 ## [1.3.2] - 2018-12-6
 
 * Added z-index attribute.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![forthebadge](https://forthebadge.com/images/badges/made-with-javascript.svg)
 ![forthebadge](https://forthebadge.com/images/badges/built-with-love.svg)
 
-[![toastify-js](https://img.shields.io/badge/toastify--js-1.3.2-brightgreen.svg)](https://www.npmjs.com/package/toastify-js)
+[![toastify-js](https://img.shields.io/badge/toastify--js-1.4-brightgreen.svg)](https://www.npmjs.com/package/toastify-js)
 
 Toastify is a lightweight, vanilla JS toast notification library.
 
@@ -47,6 +47,12 @@ yarn add toastify-js -S
 import Toastify from 'toastify-js'
 ```
 
+You can use the default CSS from Toastify as below and later override it or choose to write your own CSS.
+
+```
+import "toastify-js/src/toastify.css"
+```
+
 #### Adding ToastifyJs to HTML page using the traditional method
 
 To start using **Toastify**, add the following CSS on to your page.
@@ -75,6 +81,7 @@ Toastify({
   gravity: "top", // `top` or `bottom`
   positionLeft: true, // `true` or `false`
   backgroundColor: "linear-gradient(to right, #00b09b, #96c93d)",
+  stopOnFocus: true // Prevents dismissing of toast on hover
 }).showToast();
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "toastify-js",
-  "version": "1.3.2",
+  "version": "1.4",
   "description":
     "Toastify is a lightweight, vanilla JS toast notification library.",
   "main": "./src/toastify.js",

--- a/src/toastify.css
+++ b/src/toastify.css
@@ -1,5 +1,5 @@
 /*!
- * Toastify js 1.3.2
+ * Toastify js 1.4
  * https://github.com/apvarun/toastify-js
  * @license MIT licensed
  *

--- a/src/toastify.js
+++ b/src/toastify.js
@@ -1,5 +1,5 @@
 /*!
- * Toastify js 1.3.2
+ * Toastify js 1.4
  * https://github.com/apvarun/toastify-js
  * @license MIT licensed
  *
@@ -18,7 +18,7 @@
       return new Toastify.lib.init(options);
     },
     // Library version
-    version = "1.3.2";
+    version = "1.4";
 
   // Defining the prototype of the object
   Toastify.lib = Toastify.prototype = {

--- a/src/toastify.js
+++ b/src/toastify.js
@@ -7,7 +7,6 @@
  */
 (function(root, factory) {
   if (typeof module === "object" && module.exports) {
-    require("./toastify.css");
     module.exports = factory();
   } else {
     root.Toastify = factory();


### PR DESCRIPTION
I think we should leave that as an option for people who like to require CSS files and have a build system and process that allows that.
For all other cases, it should be an option not to.