### PR TITLE
timeOutValue is only available on divElement

### DIFF
--- a/src/toastify.js
+++ b/src/toastify.js
@@ -123,7 +123,7 @@
           divElement.addEventListener(
             "mouseover",
             function(event) {
-              window.clearTimeout(event.target.timeOutValue);
+              window.clearTimeout(divElement.timeOutValue);
             }
           )
           // add back the timeout


### PR DESCRIPTION
In the block for `stopOnFocus`, the `mouseover` handler tries to `clearTimeout` on `event.target.timeOutValue` (it assumes that `event.target` is `divElement`).

When hovering a child element though, `event.target` may not be what is expected, and `event.target.timeOutValue` will be `undefined`.

Instead, use `divElement.timeOutValue` explicitly.