### PR TITLE
Add support to close notification from a child element of "toast-close"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All the changes made to toastify-js library.
 
+## [1.6.2] - 2020-01-03
+
+* Bugfix: Closing the toast when custom close icon from icon fonts are used
+
 ## [1.6.1] - 2019-06-29
 
 * Bugfix: Disabling `stopOnFocus`

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![forthebadge](https://forthebadge.com/images/badges/made-with-javascript.svg)
 ![forthebadge](https://forthebadge.com/images/badges/built-with-love.svg)
 
-[![toastify-js](https://img.shields.io/badge/toastify--js-1.6.1-brightgreen.svg)](https://www.npmjs.com/package/toastify-js)
+[![toastify-js](https://img.shields.io/badge/toastify--js-1.6.2-brightgreen.svg)](https://www.npmjs.com/package/toastify-js)
 
 Toastify is a lightweight, vanilla JS toast notification library.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "toastify-js",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description":
     "Toastify is a lightweight, vanilla JS toast notification library.",
   "main": "./src/toastify.js",

--- a/src/toastify.css
+++ b/src/toastify.css
@@ -1,5 +1,5 @@
 /*!
- * Toastify js 1.6.1
+ * Toastify js 1.6.2
  * https://github.com/apvarun/toastify-js
  * @license MIT licensed
  *

--- a/src/toastify.js
+++ b/src/toastify.js
@@ -1,5 +1,5 @@
 /*!
- * Toastify js 1.6.1
+ * Toastify js 1.6.2
  * https://github.com/apvarun/toastify-js
  * @license MIT licensed
  *
@@ -18,7 +18,7 @@
       return new Toastify.lib.init(options);
     },
     // Library version
-    version = "1.6.1";
+    version = "1.6.2";
 
   // Defining the prototype of the object
   Toastify.lib = Toastify.prototype = {

--- a/src/toastify.js
+++ b/src/toastify.js
@@ -122,8 +122,8 @@
           "click",
           function(event) {
             event.stopPropagation();
-            this.removeElement(event.target.parentElement);
-            window.clearTimeout(event.target.parentElement.timeOutValue);
+            this.removeElement(this.toastElement);
+            window.clearTimeout(this.toastElement.timeOutValue);
           }.bind(this)
         );
 


### PR DESCRIPTION
- Customizing the close button using a font library like FontAwesome
  can dynamically create a child svg element when using its SVG+JS
  framework. When this child element triggers the close event, it
  only the close button disappears.
- If close event target is not "toast-close" element, search for the
  closest parent which has this className and pass this before trying
  to close the closeElement's parent.
- Utiltises .closest(), included Polyfill to support IE9+.