### PR TITLE
Remove the toast only, when the parent node was not removed before.

### DIFF
--- a/src/toastify.js
+++ b/src/toastify.js
@@ -249,8 +249,10 @@
       // Removing the element from DOM after transition end
       window.setTimeout(
         function() {
-          // Remove the elemenf from the DOM
-          toastElement.parentNode.removeChild(toastElement);
+          // Remove the elemenf from the DOM, only when the parent node was not removed before.
+          if (toastElement.parentNode) {
+            toastElement.parentNode.removeChild(toastElement);
+          }
 
           // Calling the callback function
           this.options.callback.call(toastElement);


### PR DESCRIPTION
When a framework like Angular(JS) or React or other code removes the parent node, the removal code may lead to an exception like this:
toastify.js:7 Uncaught TypeError: Cannot read property 'removeChild' of null
at init.<anonymous> (VM38495 toastify.js:7)