### PR TITLE
Fix width problem in position center.

### DIFF
--- a/src/toastify.css
+++ b/src/toastify.css
@@ -19,6 +19,7 @@
     border-radius: 2px;
     cursor: pointer;
     text-decoration: none;
+    width: fit-content;
     max-width: calc(50% - 20px);
     z-index: 2147483647;
 }
@@ -64,15 +65,14 @@
     margin-right: auto;
     left: 0;
     right: 0;
-    max-width: fit-content;
 }
 
 @media only screen and (max-width: 360px) {
-    .toastify-right, .toastify-left {
+    .toastify {
         margin-left: auto;
         margin-right: auto;
         left: 0;
         right: 0;
-        max-width: fit-content;
+        max-width: calc(100% - 20px);
     }
 }


### PR DESCRIPTION
Position center seems have some bug like this (captured on chrome 80):
![Center problem](https://i.imgur.com/RQLYkPu.png)
So, removed `max-width: fit-content` and adding `width: fit-content` for fix some width problem. Also adding `max-width: calc(100% - 20px)` for mobile device.

ps. `fit-content` is not working in IE.