### PR TITLE
Convert to ES6 compatible library

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,19 +134,21 @@ If `gravity` is equals to `bottom`, it will be pushed from bottom.
 | text | string | Message to be displayed in the toast | "Hi there!" |
 | node | ELEMENT_NODE | Provide a node to be mounted inside the toast. `node` takes higher precedence over `text` |  |
 | duration | number | Duration for which the toast should be displayed.<br>-1 for permanent toast | 3000 |
-| selector | string | ELEMENT_NODE | ShadowRoot | CSS Selector or Element Node on which the toast should be added | body |
+| selector | string \| ELEMENT_NODE | ShadowRoot | CSS Selector or Element Node on which the toast should be added | body |
 | destination | URL string | URL to which the browser should be navigated on click of the toast |  |
 | newWindow | boolean | Decides whether the `destination` should be opened in a new window or not | false |
 | close | boolean | To show the close icon or not | false |
 | gravity | "top" or "bottom" | To show the toast from top or bottom | "top" |
 | position | "left" or "right" | To show the toast on left or right | "right" |
-| backgroundColor | CSS background value | Sets the background color of the toast |  |
+| backgroundColor | CSS background value | Sets the background color of the toast. To be deprecated, use `style.backgroundColor` option instead |  |
 | avatar | URL string | Image/icon to be shown before text |  |
 | className | string | Ability to provide custom class name for further customization |  |
 | stopOnFocus | boolean | To stop timer when hovered over the toast (Only if duration is set) | true |
 | callback | Function | Invoked when the toast is dismissed |  |
 | onClick | Function | Invoked when the toast is clicked |  |
 | offset | Object | Ability to add some offset to axis | |
+| escapeMarkup | boolean | Toggle the default behavior of escaping HTML markup | true |
+| style | object | Use the HTML DOM Style properties to add any style directly to toast | |
 
 ## Browsers support
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ If `gravity` is equals to `bottom`, it will be pushed from bottom.
 | text | string | Message to be displayed in the toast | "Hi there!" |
 | node | ELEMENT_NODE | Provide a node to be mounted inside the toast. `node` takes higher precedence over `text` |  |
 | duration | number | Duration for which the toast should be displayed.<br>-1 for permanent toast | 3000 |
-| selector | string | CSS Selector on which the toast should be added | body |
+| selector | string | ELEMENT_NODE | ShadowRoot | CSS Selector or Element Node on which the toast should be added | body |
 | destination | URL string | URL to which the browser should be navigated on click of the toast |  |
 | newWindow | boolean | Decides whether the `destination` should be opened in a new window or not | false |
 | close | boolean | To show the close icon or not | false |

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ If `gravity` is equals to `bottom`, it will be pushed from bottom.
 | close | boolean | To show the close icon or not | false |
 | gravity | "top" or "bottom" | To show the toast from top or bottom | "top" |
 | position | "left" or "right" | To show the toast on left or right | "right" |
-| backgroundColor | CSS background value | Sets the background color of the toast. To be deprecated, use `style.backgroundColor` option instead |  |
+| backgroundColor | CSS background value | To be deprecated, use `style.background` option instead. Sets the background color of the toast |  |
 | avatar | URL string | Image/icon to be shown before text |  |
 | className | string | Ability to provide custom class name for further customization |  |
 | stopOnFocus | boolean | To stop timer when hovered over the toast (Only if duration is set) | true |

--- a/src/toastify-es.js
+++ b/src/toastify-es.js
@@ -180,13 +180,13 @@ class Toastify {
   
       // Creating the DOM object
       let divElement = document.createElement("div");
-      divElement.className = "toastify on " + this.options.className;
+      divElement.className = `toastify on ${this.options.className}`;
   
       // Positioning toast to left or right or center (default right)
-      divElement.className += " toastify-" + this.options.position;
+      divElement.className += ` toastify-${this.options.position}`;
   
       // Assigning gravity of element
-      divElement.className += " " + this.options.gravity;
+      divElement.className += ` ${this.options.gravity}`;
   
       if (this.options.backgroundColor) {
         divElement.style.background = this.options.backgroundColor;
@@ -300,8 +300,8 @@ class Toastify {
       // Adding offset
       if (typeof this.options.offset === "object") {
   
-        var x = getAxisOffsetAValue("x", this.options);
-        var y = getAxisOffsetAValue("y", this.options);
+        var x = this._getAxisOffsetAValue("x", this.options);
+        var y = this._getAxisOffsetAValue("y", this.options);
   
         var xOffset = this.options.position == "left" ? x : "-" + x;
         var yOffset = this.options.gravity == "toastify-top" ? y : "-" + y;
@@ -389,45 +389,46 @@ class Toastify {
         // Show toast in center if screen with less than or qual to 360px
         if (width <= 360) {
           // Setting the position
-          allToasts[i].style[classUsed] = offsetSize[classUsed] + "px";
+          allToasts[i].style[classUsed] = `${offsetSize[classUsed]}px`;
     
           offsetSize[classUsed] += height + offset;
         } else {
           if (allToasts[i].classList.contains("toastify-left") === true) {
             // Setting the position
-            allToasts[i].style[classUsed] = topLeftOffsetSize[classUsed] + "px";
+            allToasts[i].style[classUsed] = `${topLeftOffsetSize[classUsed]}px`;
     
             topLeftOffsetSize[classUsed] += height + offset;
           } else {
             // Setting the position
-            allToasts[i].style[classUsed] = topRightOffsetSize[classUsed] + "px";
+            allToasts[i].style[classUsed] = `${topRightOffsetSize[classUsed]}px`;
     
             topRightOffsetSize[classUsed] += height + offset;
           }
         }
       }
     }
-  
-  }
-  
-  /**
-   * Helper function to get offset
-   * @param {string} axis - 'x' or 'y'
-   * @param {ToastifyConfigurationObject} options - The options object containing the offset object
-   */
-  function getAxisOffsetAValue(axis, options) {
-  
-    if (options.offset[axis]) {
-      if (isNaN(options.offset[axis])) {
-        return options.offset[axis];
-      } else {
-        return options.offset[axis] + 'px';
+
+    /**
+     * Helper function to get offset
+     * @param {string} axis - 'x' or 'y'
+     * @param {ToastifyConfigurationObject} options - The options object containing the offset object
+     */
+    _getAxisOffsetAValue(axis, options) {
+    
+      if (options.offset[axis]) {
+        if (isNaN(options.offset[axis])) {
+          return options.offset[axis];
+        } else {
+          return `${options.offset[axis]}px`;
+        }
       }
+    
+      return '0px';
+    
     }
   
-    return '0px';
-  
   }
+  
   
   // Returning the Toastify function to be assigned to the window object/module
   function StartToastifyInstance(options) {

--- a/src/toastify-es.js
+++ b/src/toastify-es.js
@@ -73,7 +73,7 @@ class Toastify {
       // Getting the root element to with the toast needs to be added
       if (typeof this.options.selector === "string") {
         this._rootElement = document.getElementById(this.options.selector);
-      } else if (this.options.selector instanceof HTMLElement) {
+      } else if (this.options.selector instanceof HTMLElement || this.options.selector instanceof ShadowRoot) {
         this._rootElement = this.options.selector;
       } else {
         this._rootElement = document.body;
@@ -365,7 +365,7 @@ class Toastify {
       };
     
       // Get all toast messages that have been added to the container (selector)
-      let allToasts = this._rootElement.getElementsByClassName("toastify");
+      let allToasts = this._rootElement.querySelectorAll(".toastify");
     
       let classUsed;
     

--- a/src/toastify-es.js
+++ b/src/toastify-es.js
@@ -18,7 +18,7 @@
  * @property {boolean} close - To show the close icon or not
  * @property {string} gravity - To show the toast from top or bottom
  * @property {string} position - To show the toast on left or right
- * @property {string} backgroundColor - Sets the background color of the toast
+ * @property {string} backgroundColor - Sets the background color of the toast (to be deprecated)
  * @property {url} avatar - Image/icon to be shown before text
  * @property {string} className - Ability to provide custom class name for further customization
  * @property {boolean} stopOnFocus - To stop timer when hovered over the toast (Only if duration is set)
@@ -26,6 +26,7 @@
  * @property {Function} onClick - Invoked when the toast is clicked
  * @property {Object} offset - Ability to add some offset to axis
  * @property {boolean} escapeMarkup - Toggle the default behavior of escaping HTML markup
+ * @property {Object} style - Use the HTML DOM style property to add styles to toast
  */
 
 
@@ -128,7 +129,7 @@ class Toastify {
      * @param {boolean} [options.close=false] - To show the close icon or not
      * @param {string} [options.gravity=toastify-top] - To show the toast from top or bottom
      * @param {string} [options.position=right] - To show the toast on left or right
-     * @param {string} [options.backgroundColor] - Sets the background color of the toast
+     * @param {string} [options.backgroundColor] - Sets the background color of the toast (To be deprecated)
      * @param {url} [options.avatar] - Image/icon to be shown before text
      * @param {string} [options.className] - Ability to provide custom class name for further customization
      * @param {boolean} [options.stopOnFocus] - To stop timer when hovered over the toast (Only if duration is set)
@@ -136,6 +137,7 @@ class Toastify {
      * @param {Function} [options.onClick] - Invoked when the toast is clicked
      * @param {Object} [options.offset] - Ability to add some offset to axis
      * @param {boolean} [options.escapeMarkup=true] - Toggle the default behavior of escaping HTML markup
+     * @param {Object} [options.style] - Use the HTML DOM style property to add styles to toast
      * @private
      */
     _init(options) {
@@ -161,7 +163,8 @@ class Toastify {
           x: 0,
           y: 0
         },
-        escapeMarkup: true
+        escapeMarkup: true,
+        style: {}
       }, options);
       this.toastElement = null;
   
@@ -192,7 +195,14 @@ class Toastify {
       divElement.className += ` ${this.options.gravity}`;
   
       if (this.options.backgroundColor) {
+        // This is being deprecated in favor of using the style HTML DOM property
+        console.warn('DEPRECATION NOTICE: "backgroundColor" is being deprecated. Please use the "style.backgroundColor" property.');
         divElement.style.background = this.options.backgroundColor;
+      }
+
+      // Loop through our style object and apply styles to divElement
+      for (const property in this.options.style) {
+        divElement.style[property] = this.options.style[property];
       }
   
       // Adding the toast message/node

--- a/src/toastify-es.js
+++ b/src/toastify-es.js
@@ -171,6 +171,7 @@ class Toastify {
       this.options.gravity = options.gravity === "bottom" ? "toastify-bottom" : "toastify-top"; // toast position - top or bottom
       this.options.stopOnFocus = options.stopOnFocus === undefined ? true : options.stopOnFocus; // stop timeout on focus
   
+      this.options.style.background = this.options.style.background || options.backgroundColor;
     }
   
     /**
@@ -196,9 +197,7 @@ class Toastify {
   
       if (this.options.backgroundColor) {
         // This is being deprecated in favor of using the style HTML DOM property
-        // We'll go ahead and just add the `backgroundColor` to the `style` object to simulate correct settings moving forward
         console.warn('DEPRECATION NOTICE: "backgroundColor" is being deprecated. Please use the "style.background" property.');
-        this.options.style.background = this.options.backgroundColor;
       }
 
       // Loop through our style object and apply styles to divElement

--- a/src/toastify-es.js
+++ b/src/toastify-es.js
@@ -200,7 +200,7 @@ class Toastify {
         divElement.innerText = this.options.text;
   
         if (this.options.avatar !== "") {
-          var avatarElement = document.createElement("img");
+          let avatarElement = document.createElement("img");
           avatarElement.src = this.options.avatar;
   
           avatarElement.className = "toastify-avatar";
@@ -234,7 +234,7 @@ class Toastify {
         );
   
         //Calculating screen width
-        var width = window.innerWidth > 0 ? window.innerWidth : screen.width;
+        const width = window.innerWidth > 0 ? window.innerWidth : screen.width;
   
         // Adding the close icon to the toast element
         // Display on the right if screen width is less than or equal to 360px
@@ -299,13 +299,13 @@ class Toastify {
       // Adding offset
       if (typeof this.options.offset === "object") {
   
-        var x = this._getAxisOffsetAValue("x", this.options);
-        var y = this._getAxisOffsetAValue("y", this.options);
+        const x = this._getAxisOffsetAValue("x", this.options);
+        const y = this._getAxisOffsetAValue("y", this.options);
   
-        var xOffset = this.options.position == "left" ? x : "-" + x;
-        var yOffset = this.options.gravity == "toastify-top" ? y : "-" + y;
+        const xOffset = this.options.position == "left" ? x : `-${x}`;
+        const yOffset = this.options.gravity == "toastify-top" ? y : `-${y}`;
   
-        divElement.style.transform = "translate(" + xOffset + "," + yOffset + ")";
+        divElement.style.transform = `translate(${xOffset},${yOffset})`;
   
       }
   

--- a/src/toastify-es.js
+++ b/src/toastify-es.js
@@ -196,8 +196,9 @@ class Toastify {
   
       if (this.options.backgroundColor) {
         // This is being deprecated in favor of using the style HTML DOM property
-        console.warn('DEPRECATION NOTICE: "backgroundColor" is being deprecated. Please use the "style.backgroundColor" property.');
-        divElement.style.background = this.options.backgroundColor;
+        // We'll go ahead and just add the `backgroundColor` to the `style` object to simulate correct settings moving forward
+        console.warn('DEPRECATION NOTICE: "backgroundColor" is being deprecated. Please use the "style.background" property.');
+        this.options.style.background = this.options.backgroundColor;
       }
 
       // Loop through our style object and apply styles to divElement

--- a/src/toastify-es.js
+++ b/src/toastify-es.js
@@ -1,0 +1,437 @@
+/*!
+ * Toastify js 1.9.3
+ * https://github.com/apvarun/toastify-js
+ * @license MIT licensed
+ *
+ * Copyright (C) 2018 Varun A P
+ */
+
+/**
+ * Options used for Toastify
+ * @typedef {Object} ToastifyConfigurationObject
+ * @property {string} text - Message to be displayed in the toast
+ * @property {Element} node - Provide a node to be mounted inside the toast. node takes higher precedence over text
+ * @property {number} duration - Duration for which the toast should be displayed. -1 for permanent toast
+ * @property {string|Element} selector - CSS ID Selector on which the toast should be added
+ * @property {url} destination - URL to which the browser should be navigated on click of the toast
+ * @property {boolean} newWindow - Decides whether the destination should be opened in a new window or not
+ * @property {boolean} close - To show the close icon or not
+ * @property {string} gravity - To show the toast from top or bottom
+ * @property {string} position - To show the toast on left or right
+ * @property {string} backgroundColor - Sets the background color of the toast
+ * @property {url} avatar - Image/icon to be shown before text
+ * @property {string} className - Ability to provide custom class name for further customization
+ * @property {boolean} stopOnFocus - To stop timer when hovered over the toast (Only if duration is set)
+ * @property {Function} callback - Invoked when the toast is dismissed
+ * @property {Function} onClick - Invoked when the toast is clicked
+ * @property {Object} offset - Ability to add some offset to axis
+ */
+
+
+class Toastify {
+
+    constructor(options) {
+      /**
+       * The version of Toastify
+       * @type {string}
+       * @public
+       */
+      this.version = "1.9.3";
+  
+      /**
+       * The configuration object to configure Toastify
+       * @type {ToastifyConfigurationObject}
+       * @public
+       */
+      this.options = {};
+  
+      /**
+       * The element that is the Toast
+       * @type {Element}
+       * @public
+       */
+      this.toastElement = null;
+  
+      /**
+       * The root element that contains all the toasts
+       * @type {Element}
+       * @private
+       */
+      this._rootElement = document.body;
+      
+      this._init(options);
+    }
+  
+    /**
+     * Display the toast
+     * @public
+     */
+    showToast() {
+      // Creating the DOM object for the toast
+      this.toastElement = this._buildToast();
+  
+      // Getting the root element to with the toast needs to be added
+      if (typeof this.options.selector === "string") {
+        this._rootElement = document.getElementById(this.options.selector);
+      } else if (this.options.selector instanceof HTMLElement) {
+        this._rootElement = this.options.selector;
+      } else {
+        this._rootElement = document.body;
+      }
+  
+      // Validating if root element is present in DOM
+      if (!this._rootElement) {
+        throw "Root element is not defined";
+      }
+  
+      // Adding the DOM element
+      this._rootElement.insertBefore(this.toastElement, this._rootElement.firstChild);
+  
+      // Repositioning the toasts in case multiple toasts are present
+      this._reposition();
+  
+      if (this.options.duration > 0) {
+        this.toastElement.timeOutValue = window.setTimeout(
+          () => {
+            // Remove the toast from DOM
+            this._removeElement(this.toastElement);
+          },
+          this.options.duration
+        ); // Binding `this` for function invocation
+      }
+  
+      // Supporting function chaining
+      return this;
+    }
+  
+    /**
+     * Hide the toast
+     * @public
+     */
+    hideToast() {
+      if (this.toastElement.timeOutValue) {
+        clearTimeout(this.toastElement.timeOutValue);
+      }
+      this._removeElement(this.toastElement);
+    }
+  
+    /**
+     * Init the Toastify class
+     * @param {ToastifyConfigurationObject} options - The configuration object to configure Toastify
+     * @param {string} [options.text=Hi there!] - Message to be displayed in the toast
+     * @param {Element} [options.node] - Provide a node to be mounted inside the toast. node takes higher precedence over text
+     * @param {number} [options.duration=3000] - Duration for which the toast should be displayed. -1 for permanent toast
+     * @param {string} [options.selector] - CSS Selector on which the toast should be added
+     * @param {url} [options.destination] - URL to which the browser should be navigated on click of the toast
+     * @param {boolean} [options.newWindow=false] - Decides whether the destination should be opened in a new window or not
+     * @param {boolean} [options.close=false] - To show the close icon or not
+     * @param {string} [options.gravity=toastify-top] - To show the toast from top or bottom
+     * @param {string} [options.position=right] - To show the toast on left or right
+     * @param {string} [options.backgroundColor] - Sets the background color of the toast
+     * @param {url} [options.avatar] - Image/icon to be shown before text
+     * @param {string} [options.className] - Ability to provide custom class name for further customization
+     * @param {boolean} [options.stopOnFocus] - To stop timer when hovered over the toast (Only if duration is set)
+     * @param {Function} [options.callback] - Invoked when the toast is dismissed
+     * @param {Function} [options.onClick] - Invoked when the toast is clicked
+     * @param {Object} [options.offset] - Ability to add some offset to axis
+     * @private
+     */
+    _init(options) {
+  
+      // Setting defaults
+      this.options = Object.assign({
+        text: "Hi there!",
+        node: undefined,
+        duration: 3000,
+        selector: undefined,
+        callback: function() {},
+        destination: undefined,
+        newWindow: false,
+        close: false,
+        gravity: "toastify-top",
+        position: "right",
+        backgroundColor: undefined,
+        avatar: "",
+        className: "",
+        stopOnFocus: undefined,
+        onClick: undefined,
+        offset: {
+          x: 0,
+          y: 0
+        }
+      }, options);
+      this.toastElement = null;
+  
+      this.options.gravity = options.gravity === "bottom" ? "toastify-bottom" : "toastify-top"; // toast position - top or bottom
+      this.options.stopOnFocus = options.stopOnFocus === undefined ? true : options.stopOnFocus; // stop timeout on focus
+  
+    }
+  
+    /**
+     * Build the Toastify element
+     * @returns {Element}
+     * @private
+     */
+    _buildToast() {
+      // Validating if the options are defined
+      if (!this.options) {
+        throw "Toastify is not initialized";
+      }
+  
+      // Creating the DOM object
+      let divElement = document.createElement("div");
+      divElement.className = "toastify on " + this.options.className;
+  
+      // Positioning toast to left or right or center (default right)
+      divElement.className += " toastify-" + this.options.position;
+  
+      // Assigning gravity of element
+      divElement.className += " " + this.options.gravity;
+  
+      if (this.options.backgroundColor) {
+        divElement.style.background = this.options.backgroundColor;
+      }
+  
+      // Adding the toast message/node
+      if (this.options.node && this.options.node.nodeType === Node.ELEMENT_NODE) {
+        // If we have a valid node, we insert it
+        divElement.appendChild(this.options.node)
+      } else {
+        //TODO: Prevent/Warn of XSS issues with innerHTML
+        divElement.innerHTML = this.options.text;
+  
+        if (this.options.avatar !== "") {
+          var avatarElement = document.createElement("img");
+          avatarElement.src = this.options.avatar;
+  
+          avatarElement.className = "toastify-avatar";
+  
+          if (this.options.position == "left") {
+            // Adding close icon on the left of content
+            divElement.appendChild(avatarElement);
+          } else {
+            // Adding close icon on the right of content
+            divElement.insertAdjacentElement("afterbegin", avatarElement);
+          }
+        }
+      }
+  
+      // Adding a close icon to the toast
+      if (this.options.close === true) {
+        // Create a span for close element
+        let closeElement = document.createElement("span");
+        closeElement.innerHTML = "&#10006;";
+  
+        closeElement.className = "toast-close";
+  
+        // Triggering the removal of toast from DOM on close click
+        closeElement.addEventListener(
+          "click",
+          (event) => {
+            event.stopPropagation();
+            this._removeElement(this.toastElement);
+            window.clearTimeout(this.toastElement.timeOutValue);
+          }
+        );
+  
+        //Calculating screen width
+        var width = window.innerWidth > 0 ? window.innerWidth : screen.width;
+  
+        // Adding the close icon to the toast element
+        // Display on the right if screen width is less than or equal to 360px
+        if ((this.options.position == "left") && width > 360) {
+          // Adding close icon on the left of content
+          divElement.insertAdjacentElement("afterbegin", closeElement);
+        } else {
+          // Adding close icon on the right of content
+          divElement.appendChild(closeElement);
+        }
+      }
+  
+      // Clear timeout while toast is focused
+      if (this.options.stopOnFocus && this.options.duration > 0) {
+        // stop countdown
+        divElement.addEventListener(
+          "mouseover",
+          (event) => {
+            window.clearTimeout(divElement.timeOutValue);
+          }
+        )
+        // add back the timeout
+        divElement.addEventListener(
+          "mouseleave",
+          () => {
+            divElement.timeOutValue = window.setTimeout(
+              () => {
+                // Remove the toast from DOM
+                this._removeElement(divElement);
+              },
+              this.options.duration
+            )
+          }
+        )
+      }
+  
+      // Adding an on-click destination path
+      if (typeof this.options.destination !== "undefined") {
+        divElement.addEventListener(
+          "click",
+          (event) => {
+            event.stopPropagation();
+            if (this.options.newWindow === true) {
+              window.open(this.options.destination, "_blank");
+            } else {
+              window.location = this.options.destination;
+            }
+          }
+        );
+      }
+  
+      if (typeof this.options.onClick === "function" && typeof this.options.destination === "undefined") {
+        divElement.addEventListener(
+          "click",
+          (event) => {
+            event.stopPropagation();
+            this.options.onClick();
+          }
+        );
+      }
+  
+      // Adding offset
+      if (typeof this.options.offset === "object") {
+  
+        var x = getAxisOffsetAValue("x", this.options);
+        var y = getAxisOffsetAValue("y", this.options);
+  
+        var xOffset = this.options.position == "left" ? x : "-" + x;
+        var yOffset = this.options.gravity == "toastify-top" ? y : "-" + y;
+  
+        divElement.style.transform = "translate(" + xOffset + "," + yOffset + ")";
+  
+      }
+  
+      // Returning the generated element
+      return divElement;
+    }
+  
+    /**
+     * Remove the toast from the DOM
+     * @param {Element} toastElement 
+     */
+    _removeElement(toastElement) {
+      // Hiding the element
+      toastElement.className = toastElement.className.replace(" on", "");
+  
+      // Removing the element from DOM after transition end
+      window.setTimeout(
+        () => {
+          // remove options node if any
+          if (this.options.node && this.options.node.parentNode) {
+            this.options.node.parentNode.removeChild(this.options.node);
+          }
+  
+          // Remove the elemenf from the DOM, only when the parent node was not removed before.
+          if (toastElement.parentNode) {
+            toastElement.parentNode.removeChild(toastElement);
+          }
+  
+          // Calling the callback function
+          this.options.callback.call(toastElement);
+  
+          // Repositioning the toasts again
+          this._reposition();
+        },
+        400
+      ); // Binding `this` for function invocation
+    }
+  
+    /**
+     * Position the toast on the DOM
+     * @private
+     */
+    _reposition() {
+  
+      // Top margins with gravity
+      let topLeftOffsetSize = {
+        top: 15,
+        bottom: 15,
+      };
+      let topRightOffsetSize = {
+        top: 15,
+        bottom: 15,
+      };
+      let offsetSize = {
+        top: 15,
+        bottom: 15,
+      };
+    
+      // Get all toast messages that have been added to the container (selector)
+      let allToasts = this._rootElement.getElementsByClassName("toastify");
+    
+      let classUsed;
+    
+      // Modifying the position of each toast element
+      for (let i = 0; i < allToasts.length; i++) {
+        // Getting the applied gravity
+        if (allToasts[i].classList.contains("toastify-top") === true) {
+          classUsed = "toastify-top";
+        } else {
+          classUsed = "toastify-bottom";
+        }
+    
+        let height = allToasts[i].offsetHeight;
+        classUsed = classUsed.substr(9, classUsed.length - 1)
+        // Spacing between toasts
+        let offset = 15;
+    
+        let width = window.innerWidth > 0 ? window.innerWidth : screen.width;
+    
+        // Show toast in center if screen with less than or qual to 360px
+        if (width <= 360) {
+          // Setting the position
+          allToasts[i].style[classUsed] = offsetSize[classUsed] + "px";
+    
+          offsetSize[classUsed] += height + offset;
+        } else {
+          if (allToasts[i].classList.contains("toastify-left") === true) {
+            // Setting the position
+            allToasts[i].style[classUsed] = topLeftOffsetSize[classUsed] + "px";
+    
+            topLeftOffsetSize[classUsed] += height + offset;
+          } else {
+            // Setting the position
+            allToasts[i].style[classUsed] = topRightOffsetSize[classUsed] + "px";
+    
+            topRightOffsetSize[classUsed] += height + offset;
+          }
+        }
+      }
+    }
+  
+  }
+  
+  /**
+   * Helper function to get offset
+   * @param {string} axis - 'x' or 'y'
+   * @param {ToastifyConfigurationObject} options - The options object containing the offset object
+   */
+  function getAxisOffsetAValue(axis, options) {
+  
+    if (options.offset[axis]) {
+      if (isNaN(options.offset[axis])) {
+        return options.offset[axis];
+      } else {
+        return options.offset[axis] + 'px';
+      }
+    }
+  
+    return '0px';
+  
+  }
+  
+  // Returning the Toastify function to be assigned to the window object/module
+  function StartToastifyInstance(options) {
+    return new Toastify(options);
+  }
+  
+  export default StartToastifyInstance;

--- a/src/toastify-es.js
+++ b/src/toastify-es.js
@@ -197,8 +197,7 @@ class Toastify {
         // If we have a valid node, we insert it
         divElement.appendChild(this.options.node)
       } else {
-        //TODO: Prevent/Warn of XSS issues with innerHTML
-        divElement.innerHTML = this.options.text;
+        divElement.innerText = this.options.text;
   
         if (this.options.avatar !== "") {
           var avatarElement = document.createElement("img");

--- a/src/toastify-es.js
+++ b/src/toastify-es.js
@@ -18,7 +18,7 @@
  * @property {boolean} close - To show the close icon or not
  * @property {string} gravity - To show the toast from top or bottom
  * @property {string} position - To show the toast on left or right
- * @property {string} backgroundColor - Sets the background color of the toast (to be deprecated)
+ * @property {string} backgroundColor - Deprecated: Sets the background color of the toast
  * @property {url} avatar - Image/icon to be shown before text
  * @property {string} className - Ability to provide custom class name for further customization
  * @property {boolean} stopOnFocus - To stop timer when hovered over the toast (Only if duration is set)
@@ -166,6 +166,12 @@ class Toastify {
         escapeMarkup: true,
         style: {}
       }, options);
+      
+      if (this.options.backgroundColor) {
+        // This is being deprecated in favor of using the style HTML DOM property
+        console.warn('DEPRECATION NOTICE: "backgroundColor" is being deprecated. Please use the "style.background" property.');
+      }
+
       this.toastElement = null;
   
       this.options.gravity = options.gravity === "bottom" ? "toastify-bottom" : "toastify-top"; // toast position - top or bottom
@@ -194,11 +200,6 @@ class Toastify {
   
       // Assigning gravity of element
       divElement.className += ` ${this.options.gravity}`;
-  
-      if (this.options.backgroundColor) {
-        // This is being deprecated in favor of using the style HTML DOM property
-        console.warn('DEPRECATION NOTICE: "backgroundColor" is being deprecated. Please use the "style.background" property.');
-      }
 
       // Loop through our style object and apply styles to divElement
       for (const property in this.options.style) {

--- a/src/toastify-es.js
+++ b/src/toastify-es.js
@@ -25,6 +25,7 @@
  * @property {Function} callback - Invoked when the toast is dismissed
  * @property {Function} onClick - Invoked when the toast is clicked
  * @property {Object} offset - Ability to add some offset to axis
+ * @property {boolean} escapeMarkup - Toggle the default behavior of escaping HTML markup
  */
 
 
@@ -134,6 +135,7 @@ class Toastify {
      * @param {Function} [options.callback] - Invoked when the toast is dismissed
      * @param {Function} [options.onClick] - Invoked when the toast is clicked
      * @param {Object} [options.offset] - Ability to add some offset to axis
+     * @param {boolean} [options.escapeMarkup=true] - Toggle the default behavior of escaping HTML markup
      * @private
      */
     _init(options) {
@@ -158,7 +160,8 @@ class Toastify {
         offset: {
           x: 0,
           y: 0
-        }
+        },
+        escapeMarkup: true
       }, options);
       this.toastElement = null;
   
@@ -197,7 +200,11 @@ class Toastify {
         // If we have a valid node, we insert it
         divElement.appendChild(this.options.node)
       } else {
-        divElement.innerText = this.options.text;
+        if (this.options.escapeMarkup) {
+          divElement.innerText = this.options.text;
+        } else {
+          divElement.innerHTML = this.options.text;
+        }
   
         if (this.options.avatar !== "") {
           let avatarElement = document.createElement("img");

--- a/src/toastify.js
+++ b/src/toastify.js
@@ -61,6 +61,8 @@
       this.options.escapeMarkup = options.escapeMarkup !== undefined ? options.escapeMarkup : true;
       this.options.style = options.style || {};
 
+      this.options.style.background = this.options.style.background || options.backgroundColor;
+
       // Returning the current object for chaining functions
       return this;
     },
@@ -95,9 +97,7 @@
 
       if (this.options.backgroundColor) {
         // This is being deprecated in favor of using the style HTML DOM property
-        // We'll go ahead and just add the `backgroundColor` to the `style` object to simulate correct settings moving forward
         console.warn('DEPRECATION NOTICE: "backgroundColor" is being deprecated. Please use the "style.background" property.');
-        this.options.style.background = this.options.backgroundColor;
       }
 
       // Loop through our style object and apply styles to divElement

--- a/src/toastify.js
+++ b/src/toastify.js
@@ -94,9 +94,10 @@
       divElement.className += " " + this.options.gravity;
 
       if (this.options.backgroundColor) {
-        //This is being deprecated in favor of using the style HTML DOM property
-        console.warn('DEPRECATION NOTICE: "backgroundColor" is being deprecated. Please use the "style.backgroundColor" property.');
-        divElement.style.background = this.options.backgroundColor;
+        // This is being deprecated in favor of using the style HTML DOM property
+        // We'll go ahead and just add the `backgroundColor` to the `style` object to simulate correct settings moving forward
+        console.warn('DEPRECATION NOTICE: "backgroundColor" is being deprecated. Please use the "style.background" property.');
+        this.options.style.background = this.options.backgroundColor;
       }
 
       // Loop through our style object and apply styles to divElement

--- a/src/toastify.js
+++ b/src/toastify.js
@@ -59,6 +59,7 @@
       this.options.offset = options.offset || { x: 0, y: 0 }; // toast offset
 
       this.options.escapeMarkup = options.escapeMarkup !== undefined ? options.escapeMarkup : true;
+      this.options.style = options.style || {};
 
       // Returning the current object for chaining functions
       return this;
@@ -93,7 +94,14 @@
       divElement.className += " " + this.options.gravity;
 
       if (this.options.backgroundColor) {
+        //This is being deprecated in favor of using the style HTML DOM property
+        console.warn('DEPRECATION NOTICE: "backgroundColor" is being deprecated. Please use the "style.backgroundColor" property.');
         divElement.style.background = this.options.backgroundColor;
+      }
+
+      // Loop through our style object and apply styles to divElement
+      for (const property in this.options.style) {
+        divElement.style[property] = this.options.style[property];
       }
 
       // Adding the toast message/node

--- a/src/toastify.js
+++ b/src/toastify.js
@@ -58,6 +58,8 @@
 
       this.options.offset = options.offset || { x: 0, y: 0 }; // toast offset
 
+      this.options.escapeMarkup = options.escapeMarkup !== undefined ? options.escapeMarkup : true;
+
       // Returning the current object for chaining functions
       return this;
     },
@@ -99,7 +101,11 @@
         // If we have a valid node, we insert it
         divElement.appendChild(this.options.node)
       } else {
-        divElement.innerHTML = this.options.text;
+        if (this.options.escapeMarkup) {
+          divElement.innerText = this.options.text;
+        } else {
+          divElement.innerHTML = this.options.text;
+        }
 
         if (this.options.avatar !== "") {
           var avatarElement = document.createElement("img");
@@ -223,10 +229,12 @@
 
       // Getting the root element to with the toast needs to be added
       var rootElement;
-      if (typeof this.options.selector === "undefined") {
-        rootElement = document.body;
-      } else {
+      if (typeof this.options.selector === "string") {
         rootElement = document.getElementById(this.options.selector);
+      } else if (this.options.selector instanceof HTMLElement || this.options.selector instanceof ShadowRoot) {
+        rootElement = this.options.selector;
+      } else {
+        rootElement = document.body;
       }
 
       // Validating if root element is present in DOM


### PR DESCRIPTION
# ES6 Conversion + Features

Resolves #15 
Added a new file (`toastify-es.js`) which contains an ES6 compliant version of Toastify.  
Few improvements and changes to behavior:  
- Based off comments, `positionLeft` was finally removed
- Expanded functionality for selector that allows you to pass in an element as well (defaults to `document.body`)

Notable changes to code:
- Made use of arrow functions to keep context the same (replaced `(function(){...}).bind(this)`)
- `let` instead of `var`
- Toastify class rather than function. Exported function creates an instance of Toastify
- When checking classes, use the built in `classList` functionality on elements 
- `rootElement` is now stored on the class so when we remove toasts we know where to look specifically (this enhanced the ability of putting toasts inside elements and allows you to use Toastify inside shadowDom nodes)
- Added ability to use `escapeMarkup` to allow optionally unsafe `innerHTML`
- Added ability to use the HTML DOM `style` property to directly style the toast (this further extends `backgroundColor` functionality, and therefore `backgroundColor` should be deprecated in the future in favor of using `style.background`). Note, since previous functionality took `backgroundColor` and applied it to the elements `background` style (which changes all background styles), to prevent breaking changes, `backgroundColor` takes precedence over `style.backgroundColor`.

Things that should still happen:
- [x] Get maintainer feedback (I'm only human and spent a few hours quickly changing things, don't want to miss something)
- [x] Prevent XSS issues when we pass `text` into the `innerHTML` of the toast (probably just want to use `innerText`, as there's already `node` for when you want to pass in an element)
- [x] Cleanup of default values and states
- [x] Adequate testing of all use cases
- [x] Test across browsers
- [x] Include added functionality in legacy versions