### PR TITLE
Use var instead of const in legacy version

### DIFF
--- a/src/toastify.js
+++ b/src/toastify.js
@@ -124,7 +124,7 @@
       }
 
       // Loop through our style object and apply styles to divElement
-      for (const property in this.options.style) {
+      for (var property in this.options.style) {
         divElement.style[property] = this.options.style[property];
       }
 


### PR DESCRIPTION
Resolves #77 
In the non-es version, updated to use `var` rather than `const`