### PR TITLE
fix "ShadowRoot is undefined" in older browsers

### DIFF
--- a/src/toastify.js
+++ b/src/toastify.js
@@ -263,7 +263,7 @@
       var rootElement;
       if (typeof this.options.selector === "string") {
         rootElement = document.getElementById(this.options.selector);
-      } else if (this.options.selector instanceof HTMLElement || this.options.selector instanceof ShadowRoot) {
+      } else if (this.options.selector instanceof HTMLElement || (typeof ShadowRoot !== 'undefined' && this.options.selector instanceof ShadowRoot)) {
         rootElement = this.options.selector;
       } else {
         rootElement = document.body;


### PR DESCRIPTION
When using older browsers that don't support ShadowRoot (eg. Firefox <63.0) an exception is thrown and toast will not work.
Therefor checking beforehand will allow compatibility with older browsers.