### PR TITLE
Fix: Accidentally deleted duplicate declarations max-width, when build by vite.

### DIFF
--- a/src/toastify.css
+++ b/src/toastify.css
@@ -70,8 +70,13 @@
     margin-right: auto;
     left: 0;
     right: 0;
-    max-width: fit-content;
-    max-width: -moz-fit-content;
+    max-width: fit-content;   
+}
+
+@supports (max-width: -moz-fit-content) {
+    .toastify-center {
+        max-width: -moz-fit-content;
+    }
 }
 
 @media only screen and (max-width: 360px) {


### PR DESCRIPTION
Vite removes duplicate max-width declarations in CSS during the build process, keeping only the last one, which causes max-width to fail in Chrome.
Env:
vite version 4.0.0
chrome version 130.0.6723.71
toastify-js version 1.12.0